### PR TITLE
Adapt sassdash node_modules import path towards project wide node_modules

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -1,4 +1,4 @@
-@import '../node_modules/sassdash/index';
+@import '../../node_modules/sassdash/index';
 
 $_SVG_STACK: null !global;
 
@@ -23,7 +23,7 @@ $_SVG_STACK: null !global;
     children: $_SVG_STACK
   );
 
-  @if $previous != null {  
+  @if $previous != null {
     $_SVG_STACK: $previous !global;
 
     $_SVG_STACK: append($_SVG_STACK, $element) !global;


### PR DESCRIPTION
After the update to node v5.3 and npm v3.5.2 I stumbled on a wired import error:

```
Message:
    node_modules/sass-svg/scss/main.scss
Error: File to import not found or unreadable: ../node_modules/sassdash/index
       Parent style sheet: [/path/to/my/project/]node_modules/sass-svg/scss/main.scss
        on line 1 of node_modules/sass-svg/scss/main.scss
>> @import '../node_modules/sassdash/index';
```

This is probably caused by the new project wide node_modules structure that isn't a problem for javascript modules but it definitely is for sass modules. I'm quite unsure if this is a possible fix for the occurred error because there should be a better way for handling dependencies within sass modules.
