### PR TITLE
Fixed inability to use empty 'svg' root element

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -6,7 +6,7 @@
 $_SVG_STACK: null !global;
 $_SVG_DEFAULT_ATTRS: (xmlns: 'http://www.w3.org/2000/svg') !global;
 
-@mixin svg($type: 'svg', $attrs: null) {
+@mixin svg($type: 'svg', $attrs: ()) {
   $previous: $_SVG_STACK;
   $_SVG_STACK: () !global;
 


### PR DESCRIPTION
Hiya.
I've found that I was not able to use the default empty form of the svg mixin:

``` SCSS
    @include svg {
        @include svg('path', (
...
        ));
    }
```

I believe this change fixes this.
