### PR TITLE
Fix argument juggling in svg() mixin

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -6,19 +6,22 @@
 $_SVG_STACK: null !global;
 $_SVG_DEFAULT_ATTRS: (xmlns: 'http://www.w3.org/2000/svg') !global;
 
-@mixin svg($type: 'svg', $attrs: ()) {
+@mixin svg($type: null, $attrs: null) {
   $previous: $_SVG_STACK;
   $_SVG_STACK: () !global;
 
   @content;
 
   // Argument juggling
-  @if (type-of($type) == 'map'
+  @if ((not $type or type-of($type) == 'map')
     and not $attrs
     and not $previous
   ) {
     $attrs: $type;
     $type: 'svg';
+  }
+  @if (not $attrs) {
+    $attrs: ();
   }
 
   $element: (


### PR DESCRIPTION
With `node-sass@4.5.3`, it looks like default arguments lead to type coercion, breaking the `type-of()` checks.

So in this line, instead of the passed map becoming the `$attrs` value, it is coerced to a string and ends up in `$type`: 

```sass
@include svg(( viewBox: 0 0 20 20 ))
```

This PR fixes that behaviour and gets the code in the README to actually compile correctly. I am not sure what broke this, and in what version of `node-sass` exactly, though.

It may also turn out that this may need to be fixed in `node-sass` instead?